### PR TITLE
fix: 드라이버가 제안하는 코스 누를 경우 나타나는 페이지 순서 변경

### DIFF
--- a/src/pages/DriverProfilePage/index.jsx
+++ b/src/pages/DriverProfilePage/index.jsx
@@ -40,7 +40,7 @@ function DriverProfilePage() {
     const dateParam = searchParams.get("date");
 
     navigation(
-      `/party/new/2?region=${driverInfo.region}&member=${memberParam || 1}&date=${dateParam || null}&driverId=${driverId}`,
+      `/party/new/4?region=${driverInfo.region}&member=${memberParam || 0}&date=${dateParam || null}&driverId=${driverId}`,
       {
         state: { selectedCourseId: selectedCourseId },
       }

--- a/src/pages/NewPartyPage/Course/index.jsx
+++ b/src/pages/NewPartyPage/Course/index.jsx
@@ -41,7 +41,7 @@ function Course({
         setSelectedCourseId={setSelectedCourseId}
         availableNewCourse={false}
       />
-      <TextArea title="날짜" content={dateToStringHan(date)} />
+      {member > 0 && <TextArea title="날짜" content={dateToStringHan(date)} />}
       <TextArea
         title="전체 파티 여행비"
         content={`${priceToString(planData.totalPrice)}원`}
@@ -68,9 +68,10 @@ function Course({
       <ReservationButton
         joinHandler={() =>
           navigation(
-            `/party/new/6?region=${region}&member=${member}&date=${date}&driverId=${driverInfo.driverId}`
+            `/party/new/${member > 0 ? 6 : 2}?region=${region}&member=${member}&date=${date}&driverId=${driverInfo.driverId}`
           )
         }
+        member={member}
       />
       <CommentList
         reviews={driverInfo.reviews}

--- a/src/pages/NewPartyPage/MemberAndDate/Member/index.jsx
+++ b/src/pages/NewPartyPage/MemberAndDate/Member/index.jsx
@@ -1,9 +1,13 @@
+import { useEffect } from "react";
 import minusGray from "../../../../assets/svg/people_minus_gray.svg";
 import minusPrimary from "../../../../assets/svg/people_minus_primary.svg";
 import plusgray from "../../../../assets/svg/people_plus_gray.svg";
 import plusPrimary from "../../../../assets/svg/people_plus_primary.svg";
 
 function Member({ member, setMember }) {
+  useEffect(() => {
+    !member > 0 && setMember(1);
+  }, []);
   const setIncrease = () => setMember(member + 1);
   const setDecrease = () => setMember(member - 1);
 

--- a/src/pages/NewPartyPage/MemberAndDate/PageButton/index.jsx
+++ b/src/pages/NewPartyPage/MemberAndDate/PageButton/index.jsx
@@ -16,9 +16,13 @@ function PageButton({ region, member, date, driverId }) {
           "h-12 rounded-full text-sm w-64 border text-white bg-primary border-primary"
         }
         onClick={() =>
-          navigation(
-            `/party/new/${driverId === 0 ? 3 : 4}?region=${region}&member=${member}&date=${date}&driverId=${driverId}`
-          )
+          driverId
+            ? navigation(
+                `/party/new/6?region=${region}&member=${member}&date=${date}&driverId=${driverId}`
+              )
+            : navigation(
+                `/party/new/3?region=${region}&member=${member}&date=${date}&driverId=${driverId}`
+              )
         }
       >
         다음


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능) -->
드라이버가 제안하는 코스 누를 경우 나타나는 페이지 순서 변경
(파티 상세 페이지가 먼저 뜨도록)

## 📸 스크린샷

<!-- 스크린샷이 필요하면 스크린샷을 첨부해주세요. (선택) -->

## 📚 참고사항 또는 리뷰 요구사항

<!-- 참고할 사항이 있다면 적어주세요. (선택) -->
