### PR TITLE
Feat : (관리자) 드라이버 프로필 수정 - 면허증 이미지 변경 + 전화번호 변경 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 # dotenv environment variable files
 .env
+.env.development

--- a/env.development
+++ b/env.development
@@ -1,0 +1,1 @@
+VITE_BASE_SERVER_URL="https://dev.mallangtrip-server.com/api"

--- a/env.development
+++ b/env.development
@@ -1,1 +1,0 @@
-VITE_BASE_SERVER_URL="https://dev.mallangtrip-server.com/api"

--- a/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
@@ -36,21 +36,6 @@ function DriverDetail() {
     "taxiLicenseImg",
     "insuranceLicenseImg",
   ];
-  // const [newLicenseImage, setNewLicenseImage] = useState([
-  //   {
-  //     key: "driverLicenseImg",
-  //     value: "",
-  //   },
-  //   {
-  //     key: "taxiLicenseImg",
-  //     value: "",
-  //   },
-  //   {
-  //     key: "insuranceLicenseImg",
-  //     value: "",
-  //   },
-  // ]);
-
   const driverId = searchParams.get("driverId");
   const profileImageHandler = () => {
     const imageFile = profileImageRef.current.files[0];

--- a/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
@@ -30,11 +30,7 @@ function DriverDetail() {
   const [showCompleteModal, setShowCompleteModal] = useState(false);
   const [autoSave, setAutoSave] = useState(true);
   const [loading, setLoading] = useState(true);
-  const newLicenseImage = [
-    "driverLicenseImg",
-    "taxiLicenseImg",
-    "insuranceLicenseImg",
-  ];
+
   const driverId = searchParams.get("driverId");
   const profileImageHandler = () => {
     const imageFile = profileImageRef.current.files[0];
@@ -49,7 +45,7 @@ function DriverDetail() {
     setNewVehicleImages((prevImgs) => [...prevImgs, imageFile]);
   };
 
-  const modifyLicenseHandler = async (index) => {
+  const modifyLicenseHandler = async (key) => {
     const imageFile = licenseImgRef.current.files[0];
     if (imageFile.size > CONSTANT.MAX_SIZE_IMAGE)
       return alert("이미지의 용량이 너무 커서 업로드 할 수 없습니다.");
@@ -57,7 +53,7 @@ function DriverDetail() {
 
     setDriverInfo((prevDriverInfo) => ({
       ...prevDriverInfo,
-      [newLicenseImage[index]]: licenseImageURL,
+      [key]: licenseImageURL,
     }));
   };
 
@@ -181,7 +177,16 @@ function DriverDetail() {
     const driverLicenseImg = driverInfo.driverLicenseImg;
     const taxiLicenseImg = driverInfo.taxiLicenseImg;
     const insuranceLicenseImg = driverInfo.insuranceLicenseImg;
-    return [driverLicenseImg, taxiLicenseImg, insuranceLicenseImg];
+
+    return [
+      { key: "driverLicenseImg", value: driverLicenseImg, name: "운전 면허증" },
+      { key: "taxiLicenseImg", value: taxiLicenseImg, name: "택시 면허증" },
+      {
+        key: "insuranceLicenseImg",
+        value: insuranceLicenseImg,
+        name: "보험 자격증",
+      },
+    ];
   }, [driverInfo]);
 
   if (loading) return <Loading full={true} />;

--- a/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   getDriverInfoDetail,
@@ -15,10 +15,12 @@ import Introduction from "../../../../../pages/MyProfilePage/DriverProfile/Intro
 import Vehicle from "../../../../../pages/MyProfilePage/DriverProfile/Vehicle";
 import Price from "../../../../../pages/MyProfilePage/DriverProfile/Price";
 import PartyCourse from "./PartyCourse";
+import License from "../../../../MyProfilePage/DriverProfile/License";
 
 function DriverDetail() {
   const profileImageRef = useRef();
   const vehicleImageRef = useRef();
+  const licenseImgRef = useRef();
   const [searchParams] = useSearchParams();
   const [driverInfo, setDriverInfo] = useState({});
   const [modifyMode, setModifyMode] = useState(false);
@@ -138,6 +140,13 @@ function DriverDetail() {
     }
   };
 
+  const modifyLicenseHandler = () => {
+    const imageFile = licenseImgRef.current.files[0];
+    if (imageFile.size > CONSTANT.MAX_SIZE_IMAGE)
+      return alert("이미지의 용량이 너무 커서 업로드 할 수 없습니다.");
+    setNewVehicleImages([...newVehicleImages, imageFile]);
+  };
+
   useEffect(() => {
     if (!modifyMode || !autoSave) return;
     setAutoSave(false);
@@ -153,6 +162,15 @@ function DriverDetail() {
     window.scrollTo({ top: 0 });
     getDriverInfoDetailFunc();
   }, [driverId]);
+
+  const licenseImgs = useMemo(
+    () => [
+      driverInfo.driverLicenseImg,
+      driverInfo.taxiLicenseImg,
+      driverInfo.insuranceLicenseImg,
+    ],
+    [driverInfo]
+  );
 
   if (loading) return <Loading full={true} />;
   return (
@@ -197,7 +215,14 @@ function DriverDetail() {
         setDriverInfo={setDriverInfo}
       />
       <PartyCourse driverInfo={driverInfo} />
-
+      <License
+        modifyMode={modifyMode}
+        driverInfo={driverInfo}
+        setDriverInfo={setDriverInfo}
+        licenseImgs={licenseImgs}
+        licenseImgRef={licenseImgRef}
+        modifyLicenseHandler={modifyLicenseHandler}
+      />
       <ConfirmModal
         showModal={showCompleteModal}
         setShowModal={setShowCompleteModal}

--- a/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
@@ -113,6 +113,7 @@ function DriverDetail() {
       const result = await getDriverInfoDetail(driverId);
       setDriverInfo(result.payload);
       setNewVehicleImages(result.payload.vehicleImgs || []);
+      console.log(result);
     } catch (e) {
       console.log(e);
     } finally {

--- a/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
@@ -30,7 +30,6 @@ function DriverDetail() {
   const [showCompleteModal, setShowCompleteModal] = useState(false);
   const [autoSave, setAutoSave] = useState(true);
   const [loading, setLoading] = useState(true);
-  const [newPhoneNum, setNewPhoneNum] = useState("");
   const newLicenseImage = [
     "driverLicenseImg",
     "taxiLicenseImg",
@@ -84,7 +83,7 @@ function DriverDetail() {
       bank: driverInfo.bank,
       holidays: driverInfo.holidays,
       introduction: driverInfo.introduction,
-      phoneNumber: driverInfo.phoneNumber,
+      phoneNumber: driverInfo.phoneNumber.replace("-", ""),
       prices: driverInfo.prices,
       profileImg: profileImageURL,
       region: driverInfo.region,
@@ -113,7 +112,6 @@ function DriverDetail() {
     try {
       const result = await getDriverInfoDetail(driverId);
       setDriverInfo(result.payload);
-      setNewPhoneNum(result.payload.phoneNumber);
       setNewVehicleImages(result.payload.vehicleImgs || []);
     } catch (e) {
       console.log(e);
@@ -142,7 +140,7 @@ function DriverDetail() {
       bank: driverInfo.bank,
       holidays: driverInfo.holidays,
       introduction: driverInfo.introduction,
-      phoneNumber: newPhoneNum,
+      phoneNumber: driverInfo.phoneNumber.replace("-", ""),
       prices: driverInfo.prices,
       profileImg: profileImageURL,
       region: driverInfo.region,
@@ -151,6 +149,9 @@ function DriverDetail() {
       vehicleModel: driverInfo.vehicleModel,
       vehicleNumber: driverInfo.vehicleNumber,
       weeklyHolidays: driverInfo.weeklyHoliday,
+      driverLicenseImg: driverInfo.driverLicenseImg,
+      taxiLicenseImg: driverInfo.taxiLicenseImg,
+      insuranceLicenseImg: driverInfo.insuranceLicenseImg,
     };
 
     try {

--- a/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
@@ -28,6 +28,7 @@ function DriverDetail() {
   const [showCompleteModal, setShowCompleteModal] = useState(false);
   const [autoSave, setAutoSave] = useState(true);
   const [loading, setLoading] = useState(true);
+  const [newPhoneNum, setNewPhoneNum] = useState("");
   const driverId = searchParams.get("driverId");
 
   const profileImageHandler = () => {
@@ -90,6 +91,7 @@ function DriverDetail() {
     try {
       const result = await getDriverInfoDetail(driverId);
       setDriverInfo(result.payload);
+      setNewPhoneNum(result.payload.phoneNumber);
       setNewVehicleImages(result.payload.vehicleImgs);
     } catch (e) {
       console.log(e);

--- a/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
@@ -113,7 +113,6 @@ function DriverDetail() {
       const result = await getDriverInfoDetail(driverId);
       setDriverInfo(result.payload);
       setNewVehicleImages(result.payload.vehicleImgs || []);
-      console.log(result);
     } catch (e) {
       console.log(e);
     } finally {

--- a/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverDetail/index.jsx
@@ -180,11 +180,15 @@ function DriverDetail() {
 
     return [
       { key: "driverLicenseImg", value: driverLicenseImg, name: "운전 면허증" },
-      { key: "taxiLicenseImg", value: taxiLicenseImg, name: "택시 면허증" },
+      {
+        key: "taxiLicenseImg",
+        value: taxiLicenseImg,
+        name: "택시 운전 면허증",
+      },
       {
         key: "insuranceLicenseImg",
         value: insuranceLicenseImg,
-        name: "보험 자격증",
+        name: "보험증서",
       },
     ];
   }, [driverInfo]);

--- a/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
@@ -12,10 +12,6 @@ function Body({
   createdAt,
 }) {
   const navigation = useNavigate();
-  const [edit, setEdit] = useState(false);
-  const handleEditor = () => {
-    setEdit(true);
-  };
 
   return (
     <div className="w-full py-3 grid grid-cols-7 items-center text-center bg-white border border-gray300 rounded-xl">
@@ -33,36 +29,10 @@ function Body({
           ? "다수"
           : driverRegion}
       </p>
-      {edit ? (
-        <div className="">
-          <input
-            className=" w-full px-1 focus:outline-none"
-            placeholder="수정할 전화번호를 입력해주세요."
-            value={phoneNumber}
-          />
-          <div className="flex gap-4 justify-center">
-            <p
-              className=" text-red-400 cursor-pointer"
-              onClick={() => setEdit(false)}
-            >
-              취소
-            </p>
-            <p className="text-blue-400 cursor-pointer">제출</p>
-          </div>
-        </div>
-      ) : (
-        <div>
-          <p className="px-1 text-gray700 font-medium">
-            {makePhoneNumber(phoneNumber)}
-          </p>
-          <p
-            className="text-gray700 font-medium hover:font-semibold cursor-pointer"
-            onClick={handleEditor}
-          >
-            수정하기
-          </p>
-        </div>
-      )}
+
+      <p className="px-1 text-gray700 font-medium">
+        {makePhoneNumber(phoneNumber)}
+      </p>
 
       <p className="px-1 text-gray500 font-medium">
         {createdAt.slice(0, 10).replaceAll("-", ".")}

--- a/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
@@ -1,6 +1,5 @@
 import { useNavigate } from "react-router-dom";
 import { makePhoneNumber } from "../../../../../../utils";
-import { useEffect } from "react";
 
 function Body({
   userId,

--- a/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
@@ -12,7 +12,6 @@ function Body({
   createdAt,
 }) {
   const navigation = useNavigate();
-  useEffect(() => {}, [phoneNumber]);
   return (
     <div className="w-full py-3 grid grid-cols-7 items-center text-center bg-white border border-gray300 rounded-xl">
       <p className="px-1 text-gray700 font-medium">{name}</p>

--- a/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { makePhoneNumber } from "../../../../../../utils";
-import { useState } from "react";
+import { useEffect } from "react";
 
 function Body({
   userId,
@@ -12,7 +12,7 @@ function Body({
   createdAt,
 }) {
   const navigation = useNavigate();
-
+  useEffect(() => {}, [phoneNumber]);
   return (
     <div className="w-full py-3 grid grid-cols-7 items-center text-center bg-white border border-gray300 rounded-xl">
       <p className="px-1 text-gray700 font-medium">{name}</p>

--- a/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverTable/Body/index.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { makePhoneNumber } from "../../../../../../utils";
+import { useState } from "react";
 
 function Body({
   userId,
@@ -11,6 +12,10 @@ function Body({
   createdAt,
 }) {
   const navigation = useNavigate();
+  const [edit, setEdit] = useState(false);
+  const handleEditor = () => {
+    setEdit(true);
+  };
 
   return (
     <div className="w-full py-3 grid grid-cols-7 items-center text-center bg-white border border-gray300 rounded-xl">
@@ -28,9 +33,37 @@ function Body({
           ? "다수"
           : driverRegion}
       </p>
-      <p className="px-1 text-gray700 font-medium">
-        {makePhoneNumber(phoneNumber)}
-      </p>
+      {edit ? (
+        <div className="">
+          <input
+            className=" w-full px-1 focus:outline-none"
+            placeholder="수정할 전화번호를 입력해주세요."
+            value={phoneNumber}
+          />
+          <div className="flex gap-4 justify-center">
+            <p
+              className=" text-red-400 cursor-pointer"
+              onClick={() => setEdit(false)}
+            >
+              취소
+            </p>
+            <p className="text-blue-400 cursor-pointer">제출</p>
+          </div>
+        </div>
+      ) : (
+        <div>
+          <p className="px-1 text-gray700 font-medium">
+            {makePhoneNumber(phoneNumber)}
+          </p>
+          <p
+            className="text-gray700 font-medium hover:font-semibold cursor-pointer"
+            onClick={handleEditor}
+          >
+            수정하기
+          </p>
+        </div>
+      )}
+
       <p className="px-1 text-gray500 font-medium">
         {createdAt.slice(0, 10).replaceAll("-", ".")}
       </p>

--- a/src/pages/AdminPage/User/DriverInfo/DriverTable/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverTable/index.jsx
@@ -15,11 +15,7 @@ function DriverTable({ userList }) {
       {userList
         .filter((user) => user.role === "ROLE_DRIVER")
         .map((driver) => {
-          return (
-            <div className="flex">
-              <Body key={driver.userId} driverInfo={driver} {...driver} />
-            </div>
-          );
+          return <Body key={driver.userId} driverInfo={driver} {...driver} />;
         })}
     </div>
   );

--- a/src/pages/AdminPage/User/DriverInfo/DriverTable/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverTable/index.jsx
@@ -16,7 +16,7 @@ function DriverTable({ userList }) {
         .map((driver) => {
           return (
             <div className="flex">
-              <Body key={driver.userId} {...driver} />
+              <Body key={driver.userId} driverInfo={driver} {...driver} />
             </div>
           );
         })}

--- a/src/pages/AdminPage/User/DriverInfo/DriverTable/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverTable/index.jsx
@@ -8,6 +8,7 @@ function DriverTable({ userList }) {
         드라이버 회원 정보가 없습니다.
       </div>
     );
+
   return (
     <div className="w-full mt-10 flex flex-col gap-2 text-sm font-semibold">
       <Head />

--- a/src/pages/AdminPage/User/DriverInfo/DriverTable/index.jsx
+++ b/src/pages/AdminPage/User/DriverInfo/DriverTable/index.jsx
@@ -13,9 +13,13 @@ function DriverTable({ userList }) {
       <Head />
       {userList
         .filter((user) => user.role === "ROLE_DRIVER")
-        .map((driver) => (
-          <Body key={driver.userId} {...driver} />
-        ))}
+        .map((driver) => {
+          return (
+            <div className="flex">
+              <Body key={driver.userId} {...driver} />
+            </div>
+          );
+        })}
     </div>
   );
 }

--- a/src/pages/MyProfilePage/DriverProfile/BasicInfo/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/BasicInfo/index.jsx
@@ -10,11 +10,6 @@ function BasicInfo({ modifyMode, driverInfo, setDriverInfo }) {
   const [showRegionModal, setShowRegionModal] = useState(false);
   const [showHolidayModal, setShowHolidayModal] = useState(false);
   const [showAccountModal, setShowAccountModal] = useState(false);
-  const [newPhoneNum, setNewPhoneNum] = useState(driverInfo.phoneNumber);
-
-  const phoneNumberHandler = (e) => {
-    setNewPhoneNum(e.target.value);
-  };
 
   return (
     <>

--- a/src/pages/MyProfilePage/DriverProfile/BasicInfo/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/BasicInfo/index.jsx
@@ -10,6 +10,11 @@ function BasicInfo({ modifyMode, driverInfo, setDriverInfo }) {
   const [showRegionModal, setShowRegionModal] = useState(false);
   const [showHolidayModal, setShowHolidayModal] = useState(false);
   const [showAccountModal, setShowAccountModal] = useState(false);
+  const [newPhoneNum, setNewPhoneNum] = useState(driverInfo.phoneNumber);
+
+  const phoneNumberHandler = (e) => {
+    setNewPhoneNum(e.target.value);
+  };
 
   return (
     <>
@@ -43,9 +48,10 @@ function BasicInfo({ modifyMode, driverInfo, setDriverInfo }) {
         <Information
           title={"전화번호"}
           content={makePhoneNumber(driverInfo.phoneNumber)}
-          // modifyMode={modifyMode}
-          // onChangeHandler={phoneNumberHandler}
-          // 본인 인증 구현되기 전까지 수정 불가 상태로 전환
+          modifyMode={modifyMode}
+          onChangeHandler={(e) =>
+            setDriverInfo({ ...driverInfo, phoneNumber: e.target.value })
+          }
         />
       </div>
 

--- a/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+
+function LicensePicture({
+  modifyMode,
+  driverInfo,
+  setDriverInfo,
+  licenseImgRef,
+  image,
+  modifyLicenseHandler,
+}) {
+  const [changeImg, setChangeImg] = useState(false);
+  return (
+    <div
+      className="shrink-0 w-1/3 h-full rounded-xl relative"
+      onMouseEnter={() => modifyMode && setChangeImg(true)}
+      onMouseLeave={() => modifyMode && setChangeImg(false)}
+    >
+      <img
+        className="w-full h-full rounded-2xl object-cover"
+        src={image}
+        alt="a"
+      />
+      {changeImg && (
+        <>
+          <div
+            className="absolute flex top-0 left-0 w-full h-full rounded-xl bg-black bg-opacity-50 cursor-pointer justify-center items-center"
+            onClick={() => licenseImgRef.current.click()}
+          >
+            <div className="tetext-sm text-white">면허증 사진 변경하기</div>
+          </div>
+          <input
+            ref={licenseImgRef}
+            className="hidden"
+            type="file"
+            accept="image/*"
+            onChange={modifyLicenseHandler}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+export default LicensePicture;

--- a/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
@@ -8,34 +8,39 @@ function LicensePicture({
   modifyLicenseHandler,
 }) {
   const [changeImg, setChangeImg] = useState(false);
+  const licenseNames = ["운전 면허증", "택시 면허증", "보험 면허증"];
+
   return (
-    <div
-      className="shrink-0 w-1/3 h-full rounded-xl relative"
-      onMouseEnter={() => modifyMode && setChangeImg(true)}
-      onMouseLeave={() => modifyMode && setChangeImg(false)}
-    >
-      <img
-        className="w-full h-full rounded-2xl object-cover"
-        src={image}
-        alt="LicenseImg"
-      />
-      {changeImg && (
-        <>
-          <div
-            className="absolute flex top-0 left-0 w-full h-full rounded-xl bg-black bg-opacity-50 cursor-pointer justify-center items-center"
-            onClick={() => licenseImgRef.current.click()}
-          >
-            <div className="tetext-sm text-white">면허증 사진 변경하기</div>
-          </div>
-          <input
-            ref={licenseImgRef}
-            className="hidden"
-            type="file"
-            accept="image/*"
-            onChange={() => modifyLicenseHandler(index)}
-          />
-        </>
-      )}
+    <div className="w-full">
+      <p className="">{licenseNames[index]}</p>
+      <div
+        className="shrink-0 w-full h-full rounded-xl relative"
+        onMouseEnter={() => modifyMode && setChangeImg(true)}
+        onMouseLeave={() => modifyMode && setChangeImg(false)}
+      >
+        <img
+          className="w-full h-full rounded-2xl object-cover"
+          src={image}
+          alt={licenseNames[index]}
+        />
+        {changeImg && (
+          <>
+            <div
+              className="absolute flex top-0 left-0 w-full h-full rounded-xl bg-black bg-opacity-50 cursor-pointer justify-center items-center"
+              onClick={() => licenseImgRef.current.click()}
+            >
+              <div className="tetext-sm text-white">면허증 사진 변경하기</div>
+            </div>
+            <input
+              ref={licenseImgRef}
+              className="hidden"
+              type="file"
+              accept="image/*"
+              onChange={() => modifyLicenseHandler(index)}
+            />
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
@@ -2,10 +2,9 @@ import { useState } from "react";
 
 function LicensePicture({
   modifyMode,
-  driverInfo,
-  setDriverInfo,
   licenseImgRef,
   image,
+  index,
   modifyLicenseHandler,
 }) {
   const [changeImg, setChangeImg] = useState(false);
@@ -18,7 +17,7 @@ function LicensePicture({
       <img
         className="w-full h-full rounded-2xl object-cover"
         src={image}
-        alt="a"
+        alt="LicenseImg"
       />
       {changeImg && (
         <>
@@ -33,7 +32,7 @@ function LicensePicture({
             className="hidden"
             type="file"
             accept="image/*"
-            onChange={modifyLicenseHandler}
+            onChange={() => modifyLicenseHandler(index)}
           />
         </>
       )}

--- a/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
@@ -12,7 +12,6 @@ function LicensePicture({
 
   return (
     <div className="w-full">
-      <p className="">{name}</p>
       <div
         className="shrink-0 w-full h-full rounded-xl relative"
         onMouseEnter={() => modifyMode && setChangeImg(true)}
@@ -29,7 +28,7 @@ function LicensePicture({
               className="absolute flex top-0 left-0 w-full h-full rounded-xl bg-black bg-opacity-50 cursor-pointer justify-center items-center"
               onClick={() => licenseImgRef.current.click()}
             >
-              <div className="tetext-sm text-white">면허증 사진 변경하기</div>
+              <div className="tetext-sm text-white">{name} 변경하기</div>
             </div>
             <input
               ref={licenseImgRef}
@@ -41,6 +40,9 @@ function LicensePicture({
           </>
         )}
       </div>
+      <p className="text-center text-darkgray text-sm mt-1 font-medium">
+        {name}
+      </p>
     </div>
   );
 }

--- a/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/LicensePicture/index.jsx
@@ -4,15 +4,15 @@ function LicensePicture({
   modifyMode,
   licenseImgRef,
   image,
-  index,
+  name,
+  keyValue,
   modifyLicenseHandler,
 }) {
   const [changeImg, setChangeImg] = useState(false);
-  const licenseNames = ["운전 면허증", "택시 면허증", "보험 면허증"];
 
   return (
     <div className="w-full">
-      <p className="">{licenseNames[index]}</p>
+      <p className="">{name}</p>
       <div
         className="shrink-0 w-full h-full rounded-xl relative"
         onMouseEnter={() => modifyMode && setChangeImg(true)}
@@ -21,7 +21,7 @@ function LicensePicture({
         <img
           className="w-full h-full rounded-2xl object-cover"
           src={image}
-          alt={licenseNames[index]}
+          alt={name}
         />
         {changeImg && (
           <>
@@ -36,7 +36,7 @@ function LicensePicture({
               className="hidden"
               type="file"
               accept="image/*"
-              onChange={() => modifyLicenseHandler(index)}
+              onChange={() => modifyLicenseHandler(keyValue)}
             />
           </>
         )}

--- a/src/pages/MyProfilePage/DriverProfile/License/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/index.jsx
@@ -12,11 +12,12 @@ function License({
         드라이버 자격증
       </p>
       <div className="flex w-full h-48 gap-2">
-        {licenseImgs.map((image, index) => (
+        {licenseImgs.map((licenseImg, index) => (
           <LicensePicture
             key={index}
-            image={image}
-            index={index}
+            image={licenseImg.value}
+            name={licenseImg.name}
+            keyValue={licenseImg.key}
             modifyMode={modifyMode}
             licenseImgRef={licenseImgRef}
             modifyLicenseHandler={modifyLicenseHandler}

--- a/src/pages/MyProfilePage/DriverProfile/License/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/index.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import LicensePicture from "./LicensePicture";
 
 function License({
@@ -22,7 +21,7 @@ function License({
             licenseImgRef={licenseImgRef}
             modifyLicenseHandler={modifyLicenseHandler}
           />
-        ))}
+        ))}{" "}
       </div>
     </>
   );

--- a/src/pages/MyProfilePage/DriverProfile/License/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/index.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import LicensePicture from "./LicensePicture";
+
+function License({
+  modifyMode,
+  driverInfo,
+  setDriverInfo,
+  licenseImgs,
+  licenseImgRef,
+  modifyLicenseHandler,
+}) {
+  return (
+    <>
+      <p className="text-lg font-bold w-full text-black mt-12 mb-5">
+        드라이버 자격증
+      </p>
+      <div className="flex w-full h-48 gap-2">
+        {licenseImgs.map((image, index) => (
+          <LicensePicture
+            key={index}
+            image={image}
+            modifyMode={modifyMode}
+            driverInfo={driverInfo}
+            setDriverInfo={setDriverInfo}
+            licenseImgRef={licenseImgRef}
+            modifyLicenseHandler={modifyLicenseHandler}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
+export default License;

--- a/src/pages/MyProfilePage/DriverProfile/License/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/index.jsx
@@ -3,8 +3,6 @@ import LicensePicture from "./LicensePicture";
 
 function License({
   modifyMode,
-  driverInfo,
-  setDriverInfo,
   licenseImgs,
   licenseImgRef,
   modifyLicenseHandler,

--- a/src/pages/MyProfilePage/DriverProfile/License/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/License/index.jsx
@@ -19,9 +19,8 @@ function License({
           <LicensePicture
             key={index}
             image={image}
+            index={index}
             modifyMode={modifyMode}
-            driverInfo={driverInfo}
-            setDriverInfo={setDriverInfo}
             licenseImgRef={licenseImgRef}
             modifyLicenseHandler={modifyLicenseHandler}
           />


### PR DESCRIPTION
## 📌 관련 이슈
closed #121 

## ✨ 작업 내용
- 어드민 페이지에서 드라이버의 전화번호 수정하는 기능을 추가했습니다.
- 어드민 페이지에서 드라이버의 면허증(운전면허증, 택시면허, 보험 관련 면허증)들을 추가했습니다.
- 어드민 페이지에서 드라이버의 면허증(운전면허증, 택시면허, 보험 관련 면허증)들을 수정할 수 있도록 했습니다.

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/559b5d3b-3715-43f6-b460-2c3271882a6b)
![image](https://github.com/user-attachments/assets/5ea07857-fea1-468d-aa6e-94b62e756269)

## 📚 참고사항 또는 리뷰 요구사항
- 유저 입장에서 운전 면허증, 택시면허, 보험 관련 면허증들을 추가해야 했는데, 세개의 면허증들을 각각 나열하는 것보다 드라이버 자격증이라는 타이틀 하에 세개를 두는 것이 접근성이 높을 것 같다고 생각해 따로 필드를 추가하지 않고 스크린샷과 같이 나열하였습니다.

- 백엔드에서는 세가지 필드가 각각 따로 전달되고 있어서, 제가 원하는 바를 효율적으로 구현하기 위해서 useMemo를 활용했습니다.