### PR TITLE
fix : 댓글에서 사진 첨부 후 댓글 목록에 사진이 업로드되지 않는 기능 수정

### DIFF
--- a/src/components/Comment/AddComment/index.jsx
+++ b/src/components/Comment/AddComment/index.jsx
@@ -69,6 +69,7 @@ function AddComment({ id, isDriver, reloadData }) {
         reloadData();
         setStar("");
         setComment("");
+        setCommentImage();
       }
     } catch (e) {
       setConfirmMessage("댓글 전송에 실패했습니다.");

--- a/src/components/Comment/CommentList/Comment/CommentImage/index.jsx
+++ b/src/components/Comment/CommentList/Comment/CommentImage/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 function CommentImage({
   modifyMode,
   image,

--- a/src/components/Comment/CommentList/Comment/CommentImage/index.jsx
+++ b/src/components/Comment/CommentList/Comment/CommentImage/index.jsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from "react";
+function CommentImage({
+  modifyMode,
+  image,
+  commentImageRef,
+  modifyImageHandler,
+}) {
+  const [imageChange, setImageChange] = useState(false);
+
+  return (
+    <div
+      onMouseEnter={() => modifyMode && setImageChange(true)}
+      onMouseLeave={() => modifyMode && setImageChange(false)}
+    >
+      <img
+        src={typeof image === "string" ? image : URL.createObjectURL(image)}
+        className="w-28 h-32"
+      />
+      {imageChange && (
+        <>
+          <div
+            className="absolute flex justify-center place-items-center top-0 left-0 w-28 h-full rounded-xl bg-black bg-opacity-50 cursor-pointer"
+            onClick={() => commentImageRef.current.click()}
+          >
+            <div className="whitespace-pre-line text-sm text-white">
+              {"이미지 변경하기"}
+            </div>
+          </div>
+          <input
+            ref={commentImageRef}
+            className="hidden"
+            type="file"
+            accept="image/*"
+            onChange={modifyImageHandler}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+export default CommentImage;

--- a/src/components/Comment/CommentList/Comment/CommentImage/index.jsx
+++ b/src/components/Comment/CommentList/Comment/CommentImage/index.jsx
@@ -14,12 +14,12 @@ function CommentImage({
     >
       <img
         src={typeof image === "string" ? image : URL.createObjectURL(image)}
-        className="w-28 h-32"
+        className="w-52 rounded-xl"
       />
       {imageChange && (
         <>
           <div
-            className="absolute flex justify-center place-items-center top-0 left-0 w-28 h-full rounded-xl bg-black bg-opacity-50 cursor-pointer"
+            className="absolute flex justify-center place-items-center top-0 left-0 w-52 h-full rounded-xl bg-black bg-opacity-50 cursor-pointer"
             onClick={() => commentImageRef.current.click()}
           >
             <div className="whitespace-pre-line text-sm text-white">

--- a/src/components/Comment/CommentList/Comment/index.jsx
+++ b/src/components/Comment/CommentList/Comment/index.jsx
@@ -70,7 +70,7 @@ function Comment({
               typeof image === "string" ? image : uploadImage(image)
             )
           )
-        : images;
+        : [];
 
     // 댓글 수정
     const body = {

--- a/src/components/Comment/CommentList/Comment/index.jsx
+++ b/src/components/Comment/CommentList/Comment/index.jsx
@@ -24,7 +24,6 @@ function Comment({
 }) {
   const user = useSelector((state) => state.user);
   const [modifyMode, setModifyMode] = useState(false);
-  const [changeImg, setChangeImg] = useState(false);
   const [newStar, setNewStar] = useState(rate.toFixed(1));
   const [newContent, setNewContent] = useState(content);
   const [newImages, setNewImages] = useState(images || []);
@@ -95,7 +94,7 @@ function Comment({
     const imageFile = commentImageRef.current.files[0];
     if (imageFile.size > CONSTANT.MAX_SIZE_IMAGE)
       return alert("이미지의 용량이 너무 커서 업로드 할 수 없습니다.");
-    setNewImages([...newImages, imageFile]);
+    setNewImages([imageFile]);
   };
 
   return (
@@ -157,7 +156,7 @@ function Comment({
         onChange={(e) => setNewContent(e.target.value)}
         disabled={!modifyMode}
       />
-      <div className="relative w-full ml-12 mt-2">
+      <div className="relative w-fit ml-12 mt-2">
         {newImages.length > 0 &&
           newImages.map((image, index) => (
             <CommentImage

--- a/src/components/Comment/CommentList/Comment/index.jsx
+++ b/src/components/Comment/CommentList/Comment/index.jsx
@@ -83,7 +83,7 @@ function Comment({
         />
         <div className="text-sm font-bold px-2.5">{nickname}</div>
         <div className="ml-2.5 flex items-center gap-1">
-          <img src={Star} />
+          <img src={Star} alt="star" />
           <input
             type="number"
             step={"0.1"}
@@ -133,6 +133,7 @@ function Comment({
         onChange={(e) => setNewContent(e.target.value)}
         disabled={!modifyMode}
       />
+      {images.length > 0 && <img src={images} />}
     </div>
   );
 }

--- a/src/pages/DestinationPage/index.jsx
+++ b/src/pages/DestinationPage/index.jsx
@@ -16,7 +16,6 @@ function DestinationPage() {
     try {
       const result = await getDestinationDetail(destinationId);
       setDestinationInfo(result.payload);
-      console.log(result.payload.reviews);
     } catch (e) {
       console.log(e);
     }

--- a/src/pages/DestinationPage/index.jsx
+++ b/src/pages/DestinationPage/index.jsx
@@ -16,6 +16,7 @@ function DestinationPage() {
     try {
       const result = await getDestinationDetail(destinationId);
       setDestinationInfo(result.payload);
+      console.log(result.payload.reviews);
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
## 📌 관련 이슈
closed #139 

## ✨ 작업 내용
- 댓글에 사진 첨부 시 댓글 목록에서 사진이 텍스트와 함께 업로드 되도록 했습니다.
- 댓글 업로드 후에도 input field에 존재했던 사진을, 전송 후에는 초기화 되도록 했습니다.

## 📚 참고사항 또는 리뷰 요구사항
해당 부분에 대한 디자인이 나오지 않은 상황이었기에 댓글에 첨부되는 사진의 이미지 크기는 임의로 설정해 놓은 상황입니다.
추후 해당 부분에 대한 디자인 피드백이 들어올 시 반영하겠습니다.
또한, 현재 기획 상 사진이 하나만 추가 및 수정이 되는 방향으로 개발했으나 백엔드의 response field의 이름명이 'images'인 점, 또 배열로 response가 온다는 점을 고려, 추후 기획이 바뀌게 될 가능성이 높다고 판단해 다수의 사진을 염두해두고 개발했습니다.
