### PR TITLE
말랑챗 채팅방 리스트 스타일 수정

### DIFF
--- a/src/components/ReportModal/index.jsx
+++ b/src/components/ReportModal/index.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useLocation } from "react-router-dom";
 import { postNewReport } from "../../api/users";
 import Loading from "../../components/Loading";
 
 function ReportModal({ showModal, setShowModal, reporteeId, targetId, type }) {
   const modalRef = useRef();
+  const location = useLocation();
   const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(false);
   const [complete, setComplete] = useState(false);
@@ -49,7 +51,11 @@ function ReportModal({ showModal, setShowModal, reporteeId, targetId, type }) {
   };
 
   useEffect(() => {
-    if (!showModal) return document.body.classList.remove("overflow-hidden");
+    if (!showModal) {
+      if (location.pathname !== "/talk")
+        document.body.classList.remove("overflow-hidden");
+      return;
+    }
     document.body.classList.add("overflow-hidden");
 
     setComplete(false);

--- a/src/pages/TalkPage/TalkList/TalkItem/index.jsx
+++ b/src/pages/TalkPage/TalkList/TalkItem/index.jsx
@@ -27,7 +27,7 @@ function TalkItem({
   return (
     <li>
       <button
-        className={`w-full flex justify-between py-3 px-3 rounded-lg hover:bg-lightgray group focus:outline-none ${
+        className={`w-full flex justify-between gap-1 py-3 px-3 rounded-lg hover:bg-lightgray group focus:outline-none ${
           openTalkId === chatRoomId ? "bg-lightgray" : "bg-white"
         }`}
         onClick={() => setOpenTalkId(chatRoomId)}
@@ -43,10 +43,10 @@ function TalkItem({
             alt="Profile_Image"
           />
           <div className="flex flex-col gap-2 text-left">
-            <div className="flex gap-4 items-center">
+            <div className="flex gap-4 items-start">
               <span className="text-lg text-black font-bold">{roomName}</span>
               {type !== "COUPLE" && (
-                <span className="text-sm text-darkgray/80 font-bold">
+                <span className="text-sm text-darkgray/80 font-bold shrink-0">
                   {headCount + "명"}
                 </span>
               )}
@@ -56,7 +56,7 @@ function TalkItem({
             </p>
           </div>
         </div>
-        <div className="flex flex-col gap-4 items-end text-left w-24">
+        <div className="flex flex-col gap-4 items-end text-left w-24 shrink-0">
           <span className="text-xs ml-auto text-darkgray font-medium">
             {chatListDateToGapKorean(updatedAt)}
           </span>


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능) -->

- 말랑챗 채팅방 리스트 스타일을 수정했습니다.
- 채팅방 이름이 길면 글자가 잘리는 문제가 있어서 이를 해결했습니다.
