### PR TITLE
말랑챗 푸시 알림 사용성 개선

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -4,17 +4,41 @@ self.addEventListener("push", (e) => {
   const resultData = e.data.json().notification;
   const tag = e.data.json().data.tag;
 
+  const isImageChat =
+    resultData.body.startsWith(
+      "https://mallang-trip-db.s3.ap-northeast-2.amazonaws.com"
+    ) && tag.startsWith("/talk?chatRoomId");
+
   const notificationTitle = resultData.title;
   const notificationOptions = {
-    body: resultData.body,
-    icon: "https://mallang-trip-db.s3.ap-northeast-2.amazonaws.com/profile/ae54463f-1299-4caa-b763-a94f5b300e27mallangtrip.png",
-    image:
-      "https://mallang-trip-db.s3.ap-northeast-2.amazonaws.com/profile/9a360955-8f22-4911-9708-53b1065f9b5amallangtrip.png",
-    tag: tag,
     ...resultData,
+    body: isImageChat ? "사진을 전송하였습니다." : resultData.body,
+    icon: "https://mallang-trip-db.s3.ap-northeast-2.amazonaws.com/profile/ae54463f-1299-4caa-b763-a94f5b300e27mallangtrip.png",
+    image: isImageChat
+      ? resultData.body
+      : "https://mallang-trip-db.s3.ap-northeast-2.amazonaws.com/profile/9a360955-8f22-4911-9708-53b1065f9b5amallangtrip.png",
+    tag: tag,
   };
 
-  self.registration.showNotification(notificationTitle, notificationOptions);
+  e.waitUntil(
+    clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        const isVisible = clientList.some((client) => {
+          return (
+            client.visibilityState === "visible" &&
+            client.url.indexOf("/talk") > 0
+          );
+        });
+
+        if (!isVisible) {
+          return self.registration.showNotification(
+            notificationTitle,
+            notificationOptions
+          );
+        }
+      })
+  );
 });
 
 self.addEventListener("notificationclick", (e) => {


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능) -->

- 말랑챗 푸시 알림 사용성을 개선했습니다.
- 사용자가 말랑챗을 보고 있으면 푸시 알림이 전송되지 않습니다.
- 사용자가 채팅으로 이미지를 전송하면, 푸시 알림으로 미리 볼 수 있습니다.