### PR TITLE
feat : 결제 수단 등록 완료시 모달창 기능 추가

### DIFF
--- a/src/components/Credit/index.jsx
+++ b/src/components/Credit/index.jsx
@@ -13,6 +13,8 @@ function Credit({ shakeCredit, register, setRegister, creditRef }) {
   const [showText, setShowText] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showErrorModal, setShowErrorModal] = useState(false);
+  const [showPaymentCompleteModal, setShowPaymentCompleteModal] =
+    useState(false);
 
   const registerCard = (type) => {
     if (type === "new" && register) return;
@@ -30,6 +32,7 @@ function Credit({ shakeCredit, register, setRegister, creditRef }) {
           if (result.statusCode !== 200) return setShowErrorModal(true);
           setCardInfo(result.payload);
           setRegister(true);
+          setShowPaymentCompleteModal(true);
         } catch (e) {
           console.log(e);
           setShowErrorModal(true);
@@ -153,6 +156,11 @@ function Credit({ shakeCredit, register, setRegister, creditRef }) {
         showModal={showErrorModal}
         setShowModal={setShowErrorModal}
         message="결제 수단 등록에 실패했습니다."
+      />
+      <ConfirmModal
+        showModal={showPaymentCompleteModal}
+        setShowModal={setShowPaymentCompleteModal}
+        message="결제 수단 등록이 완료되었습니다."
       />
     </>
   );


### PR DESCRIPTION
## 📌 관련 이슈
closed #211 

## ✨ 작업 내용
- 결제수단 등록 완료시 모달창이 뜨는 기능 추가했습니다.
- 로컬에서는 결제 수단 등록 관련 테스트가 불가해서 데브에서 못 돌려보고 그냥 로직만 검토 후 PR 날립니다.

## 📚 참고사항 또는 리뷰 요구사항
- 앞서 말했듯이, 로컬에서는 결제 수단 등록 관련 테스트가 불가해 개인적으로도 로직 관련 검토를 충분히 한 후 PR을 보냈지만, 해당 부분 조금 더 꼼꼼히 리뷰해주시면 감사하겠습니다!
