### PR TITLE
feat: 관리자 페이지 > 드라이버 정보 내 차량 이미지 확대하여 볼 수 있도록 수정

### DIFF
--- a/src/pages/MyProfilePage/DriverProfile/Vehicle/VehicleImage/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/Vehicle/VehicleImage/index.jsx
@@ -9,6 +9,7 @@ function VehicleImage({
   setNewVehicleImages,
 }) {
   const [showDelete, setShowDelete] = useState(false);
+  const [showImage, setShowImage] = useState(false);
 
   const deleteHandler = () => {
     setNewVehicleImages(newVehicleImages.filter((_, idx) => idx !== index));
@@ -16,28 +17,39 @@ function VehicleImage({
 
   return (
     <div
-      className="shrink-0 h-full rounded-xl relative"
+      className="w-1/4 shrink-0 h-full rounded-xl relative"
       onMouseEnter={() => modifyMode && setShowDelete(true)}
       onMouseLeave={() => modifyMode && setShowDelete(false)}
     >
       <img
         src={typeof image === "string" ? image : URL.createObjectURL(image)}
         alt={`vehicle_${index}`}
-        className="w-full h-full rounded-2xl object-cover"
+        className="w-full h-full rounded-2xl object-cover cursor-pointer"
+        onClick={() => setShowImage(true)}
       />
       {showDelete && (
         <>
-          <div
-            className="absolute top-0 left-0 w-full h-full rounded-xl bg-black bg-opacity-50 cursor-pointer"
-            onClick={deleteHandler}
-          >
+          <div className="absolute top-0 left-0 w-full h-full rounded-xl bg-black bg-opacity-50 cursor-pointer">
             <img
               src={deleteIcon}
               alt="delete"
+              onClick={deleteHandler}
               className="ml-auto mt-1 mr-1 w-5 h-5"
             />
           </div>
         </>
+      )}
+      {showImage && (
+        <div
+          className="fixed top-0 left-0 w-full h-full z-50 bg-[rgba(0,0,0,0.5)] flex justify-center items-center"
+          onClick={() => setShowImage(false)}
+        >
+          <img
+            src={typeof image === "string" ? image : URL.createObjectURL(image)}
+            alt={`vehicle_${index}`}
+            className="max-w-5xl"
+          />
+        </div>
       )}
     </div>
   );

--- a/src/pages/MyProfilePage/DriverProfile/Vehicle/VehicleImage/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/Vehicle/VehicleImage/index.jsx
@@ -47,7 +47,7 @@ function VehicleImage({
           <img
             src={typeof image === "string" ? image : URL.createObjectURL(image)}
             alt={`vehicle_${index}`}
-            className="max-w-5xl rounded-xl"
+            className="max-w-[80%] rounded-xl"
           />
         </div>
       )}

--- a/src/pages/MyProfilePage/DriverProfile/Vehicle/VehicleImage/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/Vehicle/VehicleImage/index.jsx
@@ -47,7 +47,7 @@ function VehicleImage({
           <img
             src={typeof image === "string" ? image : URL.createObjectURL(image)}
             alt={`vehicle_${index}`}
-            className="max-w-5xl"
+            className="max-w-5xl rounded-xl"
           />
         </div>
       )}

--- a/src/pages/MyProfilePage/DriverProfile/Vehicle/index.jsx
+++ b/src/pages/MyProfilePage/DriverProfile/Vehicle/index.jsx
@@ -45,7 +45,7 @@ function Vehicle({
         />
       </div>
       <p className="text-lg font-bold text-black mt-12 mb-5">차량 사진</p>
-      <div className="h-48 bg-cover mt-5 relative gap-[10px] flex custom-scrollbar">
+      <div className="h-48 bg-cover mt-5 pb-5 relative gap-[10px] flex custom-scrollbar">
         {modifyMode && (
           <ImageInput
             vehicleImageRef={vehicleImageRef}


### PR DESCRIPTION
## ✨ 작업 내용

- 관리자 페이지 > 드라이버 정보 내 차량 이미지 확대하여 볼 수 있도록 수정
- 관리자 페이지 > 드라이버 정보 >  프로필 수정 시 이미지가 많을 때 스크롤 바를 클릭하다가 이미지 여러 개가 한번에 지워지는 경우가 있어 x 버튼을 눌러야만 삭제 되도록 수정

